### PR TITLE
Refactor Character Header Name Editing

### DIFF
--- a/src/features/character/components/CharacterHeader.tsx
+++ b/src/features/character/components/CharacterHeader.tsx
@@ -50,7 +50,7 @@ export const CharacterHeader: React.FC<CharacterHeaderProps> = ({
     } = character;
     const grade = character.stats['Grade'] || 0;
 
-    const [isEditingName, setIsEditingName] = useState(false);
+
     const [tempName, setTempName] = useState(name);
     const [showGradeGrowth, setShowGradeGrowth] = useState(false);
 
@@ -59,7 +59,6 @@ export const CharacterHeader: React.FC<CharacterHeaderProps> = ({
     }, [name]);
 
     const handleNameSubmit = () => {
-        setIsEditingName(false);
         if (tempName !== name && onNameChange) {
             onNameChange(tempName);
         }
@@ -125,13 +124,12 @@ export const CharacterHeader: React.FC<CharacterHeaderProps> = ({
                     {/* Info */}
                     <div className="flex-1 w-full">
                         <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-2 mb-2">
-                            {isEditingName ? (
+                            {isEditMode && onNameChange ? (
                                 <Input
                                     value={tempName}
                                     onChange={(e) => setTempName(e.target.value)}
                                     onBlur={handleNameSubmit}
                                     onKeyDown={handleKeyDown}
-                                    autoFocus
                                     className="text-3xl font-bold tracking-tight h-auto py-1 px-2 w-full md:w-auto"
                                 />
                             ) : (
@@ -158,15 +156,7 @@ export const CharacterHeader: React.FC<CharacterHeaderProps> = ({
                                             )}
                                         </div>
                                     )}
-                                    {onNameChange && (
-                                        <button
-                                            onClick={() => setIsEditingName(true)}
-                                            className="text-muted-foreground hover:text-foreground p-1 hover:bg-muted rounded-md transition-colors"
-                                            title="Edit Name"
-                                        >
-                                            <Pencil className="w-5 h-5" />
-                                        </button>
-                                    )}
+
                                 </div>
                             )}
                         </div>


### PR DESCRIPTION
- Removed the specific edit button for character name.\n- Enabled name editing directly when the global 'Edit Mode' switch is active.\n- Refactored `CharacterHeader` to use `isEditMode` prop instead of internal state for visibility control.