### PR TITLE
Refactor: Repository Error Handling

### DIFF
--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -26,10 +26,14 @@ export default function CharacterListPage() {
     useEffect(() => {
         const fetchCharacters = async () => {
             try {
-                const data = await repository.listAll();
-                setCharacters(data);
+                const result = await repository.listAll();
+                if (result.isSuccess) {
+                    setCharacters(result.value);
+                } else {
+                    console.error('Failed to fetch characters', result.error);
+                }
             } catch (error) {
-                console.error('Failed to fetch characters', error);
+                console.error('Unexpected error fetching characters', error);
             } finally {
                 setIsLoading(false);
             }
@@ -52,11 +56,16 @@ export default function CharacterListPage() {
         };
 
         try {
-            await repository.save(newCharacter);
-            router.push(`/character/${newId}/setup`);
+            const result = await repository.save(newCharacter);
+            if (result.isSuccess) {
+                router.push(`/character/${newId}/setup`);
+            } else {
+                console.error('Failed to create character', result.error);
+                alert('キャラクターの作成に失敗しました。');
+            }
         } catch (error) {
-            console.error('Failed to create character', error);
-            alert('キャラクターの作成に失敗しました。');
+            console.error('Unexpected error creating character', error);
+            alert('キャラクターの作成中に予期せぬエラーが発生しました。');
         }
     };
 

--- a/src/features/character/domain/repository/ICharacterRepository.ts
+++ b/src/features/character/domain/repository/ICharacterRepository.ts
@@ -1,3 +1,5 @@
+import { AppError } from '@/domain/shared/AppError';
+import { Result } from '@/domain/shared/Result';
 import { CharacterLogEntry } from '../CharacterLog';
 
 export interface CharacterData {
@@ -17,10 +19,10 @@ export interface CharacterData {
 }
 
 export interface ICharacterRepository {
-    save(character: CharacterData): Promise<void>;
-    load(id: string): Promise<CharacterData | null>;
-    listAll(): Promise<CharacterData[]>;
-    delete(id: string): Promise<void>;
+    save(character: CharacterData): Promise<Result<void, AppError>>;
+    load(id: string): Promise<Result<CharacterData, AppError>>;
+    listAll(): Promise<Result<CharacterData[], AppError>>;
+    delete(id: string): Promise<Result<void, AppError>>;
     // In a real app, we might have methods to append logs specifically
     // appendLog(characterId: string, log: CharacterLogEntry): Promise<void>;
 }

--- a/src/features/character/infrastructure/InMemoryCharacterRepository.ts
+++ b/src/features/character/infrastructure/InMemoryCharacterRepository.ts
@@ -1,3 +1,5 @@
+import { AppError } from '@/domain/shared/AppError';
+import { err, ok, Result } from '@/domain/shared/Result';
 import { CharacterData, ICharacterRepository } from '../domain/repository/ICharacterRepository';
 
 export class InMemoryCharacterRepository implements ICharacterRepository {
@@ -155,31 +157,33 @@ export class InMemoryCharacterRepository implements ICharacterRepository {
         });
     }
 
-    async save(character: CharacterData): Promise<void> {
+    async save(character: CharacterData): Promise<Result<void, AppError>> {
         // Simulate async network delay
         await new Promise(resolve => setTimeout(resolve, 100));
         this.storage.set(character.id, character);
         console.log(`[InMemoryRepo] Saved character ${character.id}`, character);
+        return ok(undefined);
     }
 
-    async load(id: string): Promise<CharacterData | null> {
+    async load(id: string): Promise<Result<CharacterData, AppError>> {
         await new Promise(resolve => setTimeout(resolve, 100));
         const data = this.storage.get(id);
         if (!data) {
             console.warn(`[InMemoryRepo] Character ${id} not found`);
-            return data || null;
+            return err(AppError.notFound(`Character not found: ${id}`));
         }
-        return JSON.parse(JSON.stringify(data)); // Return copy
+        return ok(JSON.parse(JSON.stringify(data))); // Return copy
     }
 
-    async listAll(): Promise<CharacterData[]> {
+    async listAll(): Promise<Result<CharacterData[], AppError>> {
         await new Promise(resolve => setTimeout(resolve, 100));
-        return Array.from(this.storage.values());
+        return ok(Array.from(this.storage.values()));
     }
 
-    async delete(id: string): Promise<void> {
+    async delete(id: string): Promise<Result<void, AppError>> {
         await new Promise(resolve => setTimeout(resolve, 100));
         this.storage.delete(id);
         console.log(`[InMemoryRepo] Deleted character ${id}`);
+        return ok(undefined);
     }
 }


### PR DESCRIPTION
## 概要
Repository層のエラーハンドリングをリファクタリングし、型を使用するように変更しました。

## 変更点
- `ICharacterRepository`: 戻り値を `Promise<Result<T, AppError>>` に変更
- `SupabaseCharacterRepository`: `try-catch` でエラーを捕捉し、`Result` 型でラップして返すように変更
- `InMemoryCharacterRepository`: インターフェース変更に合わせて更新
- `page.tsx`: `listAll`, `save` の呼び出し元で `Result` 型をハンドリングするように変更
- `useCharacterSheet.ts`: `load`, `save`, `delete` の呼び出し元で `Result` 型をハンドリングするように変更

## 目的
- エラーハンドリングの統一と堅牢化
- 呼び出し元での明示的なエラー処理の強制

## テスト
- `pnpm typecheck` 通過確認済み
- 既存テストへの影響なし（Repositoryを直接モックしているテストがあれば修正が必要だが、現状はなさそう）